### PR TITLE
Handle out-of-range limits in MaxKeyAccessor

### DIFF
--- a/appstore/collections.py
+++ b/appstore/collections.py
@@ -1,4 +1,5 @@
 """Provides collection data structures."""
+from bisect import bisect_right
 from typing import Any, List, Mapping, Optional, Protocol, TypeVar
 
 
@@ -47,27 +48,15 @@ class MaxKeyAccessor:
             limit: The limit for the keys to consider.
 
         Returns:
-            The index maximum key in self._keys.
+            The index of the greatest key that is smaller than or equal to ``limit``.
+
+        The implementation uses :func:`bisect_right` to correctly handle cases where
+        ``limit`` is greater than all stored keys.
         """
-        i = 0
-        j = len(self._keys)
-        k = ((j - i) // 2) + i
-
-        while i < j:
-            if self._keys[k] == limit or (
-                k + 1 < len(self._keys) and self._keys[k] < limit < self._keys[k + 1]
-            ):
-                break
-
-            if self._keys[k] < limit:
-                i = k + 1
-
-            if self._keys[k] > limit:
-                j = k - 1
-
-            k = ((j - i) // 2) + i
-
-        return k
+        # ``bisect_right`` returns the insertion position which comes after any
+        # existing entries of ``limit``. Subtracting one gives the index of the
+        # rightmost value less than or equal to ``limit``.
+        return bisect_right(self._keys, limit) - 1
 
     def get_max(self, limit: Optional[K] = None, default: Optional[V] = None) -> V:
         """Get value for maximum key.

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -17,6 +17,9 @@ def test_max_mapping() -> None:
     # equal to limit
     assert accessor.get_max(limit=40) == 4
 
+    # limit greater than all keys
+    assert accessor.get_max(limit=60) == 5
+
     # limit smaller than keys, without default
     with pytest.raises(KeyError):
         accessor.get_max(limit=5)


### PR DESCRIPTION
## Summary
- prevent MaxKeyAccessor from raising IndexError when limit exceeds highest key
- verify accessor behavior with limit greater than all keys

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6895060948d48329a0143d4dce581b97